### PR TITLE
add stdout, stderr, and args options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea
 node_modules

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,4 @@
+{
+  "excludeFiles": ["**/node_modules/**/*"],
+  "disallowSemicolons": true
+}

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function (deps, opts, cb) {
     deps : _.isObject(opts) ? opts : {}
   deps = _.isString(deps) || _.isArray(deps) ? deps : []
 
-  let args = []
+  let args = opts.args || []
   opts.save    || args.push('-S')
   opts.saveDev || args.push('-D')
 
@@ -25,11 +25,8 @@ module.exports = function (deps, opts, cb) {
     cb()
   })
 
-  child.stdout.on('data', data => {
-    process.stdout.write(data)
-  })
-
-  child.stderr.on('data', data => {
-    process.stderr.write(data)
-  })
+  let stdout = opts.stdout || process.stdout,
+    stderr = opts.stderr || process.stderr
+  child.stdout.on('data', data => stdout.write(data))
+  child.stderr.on('data', data => stderr.write(data))
 }

--- a/test/test.js
+++ b/test/test.js
@@ -14,3 +14,17 @@ i({ path: `${__dirname}/bar` }, err => {
   if (err) throw err
   console.log('Installed in bar!')
 })
+
+var str = ''
+const stream = new require('stream').Writable({
+  write: function(chunk, encoding, next) {
+    str += chunk.toString()
+    next()
+  }
+})
+i({ stdout: stream, stderr: stream, args: ['--verbose'] }, err => {
+  if (err) throw err
+  if (!str) throw new Error('Didn\'t write to stream')
+
+  console.log('Installed with stream!')
+})


### PR DESCRIPTION
New Features
- add `stdout` and `stderr` options to use instead of process.stdout and process.stderr
- add `args` option to pass additional arguments to the npm process.

Fixes https://github.com/gerhardberger/npm-i/issues/1
